### PR TITLE
Fix includedir for client interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+*.swp
+*.o
+*.so
+sql/plexor--0.1.sql
+src/parser.tab.c
+src/parser.tab.h
+src/scanner.c
+src/scanner.h
+

--- a/makefile
+++ b/makefile
@@ -31,6 +31,7 @@ DATA_built  = $(EXT_SQL)
 SHLIB_LINK = -L$(PQLIB) -lpq
 
 #PG_CPPFLAGS = -std=c89
+PG_CPPFLAGS += -I$(PQINC)
 
 PG_CONFIG   = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)

--- a/src/execute.c
+++ b/src/execute.c
@@ -209,7 +209,7 @@ plx_send_query(PlxFn    *plx_fn,
                            arg_fmts,
                            plx_fn->is_binary))
     {
-        char *msg = psprintf("%s", PQerrorMessage(plx_conn->pq_conn));
+        char *msg = pstrdup(PQerrorMessage(plx_conn->pq_conn));
         delete_plx_conn(plx_conn);
         plx_error(plx_fn,
           "failed to send query %s %s", sql, msg);

--- a/src/execute.c
+++ b/src/execute.c
@@ -144,9 +144,14 @@ wait_for_result(PlxFn *plx_fn, PlxConn *plx_conn)
 
         if (geterrcode() == ERRCODE_QUERY_CANCELED)
             PQrequestCancel(pq_conn);
-        pg_result = PQgetResult(pq_conn);
-        if (pg_result)
+        // https://www.postgresql.org/docs/9.0/static/libpq-async.html
+        // "After successfully calling PQsendQuery, call PQgetResult 
+        // __one or more times__ to obtain the results. PQsendQuery cannot be 
+        // called again (on the same connection) until PQgetResult has returned 
+        // a null pointer, indicating that the command is done."
+        while((pg_result = PQgetResult(pq_conn))) {
             PQclear(pg_result);
+        }
         PG_RE_THROW();
     }
     PG_END_TRY();
@@ -204,9 +209,10 @@ plx_send_query(PlxFn    *plx_fn,
                            arg_fmts,
                            plx_fn->is_binary))
     {
+        char *msg = psprintf("%s", PQerrorMessage(plx_conn->pq_conn));
         delete_plx_conn(plx_conn);
         plx_error(plx_fn,
-                  "failed to send query %s %s", sql, PQerrorMessage(plx_conn->pq_conn));
+          "failed to send query %s %s", sql, msg);
     }
     wait_for_flush(plx_fn, plx_conn->pq_conn);
 }


### PR DESCRIPTION
Had error like this due to no client interface headers:

> /usr/bin/flex -osrc/scanner.c --header-file=src/scanner.h src/scanner.l
/usr/bin/bison -t -b src/parser -d src/parser.y
gcc -Wall -Wmissing-prototypes -Wpointer-arith -Wdeclaration-after-statement -Wendif-labels -Wmissing-format-attribute -Wformat-security -fno-strict-aliasing -fwrapv -fexcess-precision=standard -O2 -fpic -I. -I./ -I/usr/local/pgsql/include/server -I/usr/local/pgsql/include/internal -D_GNU_SOURCE   -c -o src/scanner.o src/scanner.c
In file included from src/scanner.l:32:0:
src/plexor.h:58:22: fatal error: libpq-fe.h: No such file or directory
compilation terminated.
<builtin>: recipe for target 'src/scanner.o' failed
make: *** [src/scanner.o] Error 1